### PR TITLE
Replace "build" with "image" in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ docker run --rm -it \
   # The UPSTREAM service must be running.
   # https://proxy.projectname.vm
   proxy:
-    build: outrigger/https-proxy:1.0
+    image: outrigger/https-proxy:1.0
     container_name: projectname_http_proxy
     depends_on:
       - api


### PR DESCRIPTION
I think that's what you meant.  Build only works if the project has been downloaded.