### PR TITLE
Modify sample code of docker-compose in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ docker run --rm -it \
   # The UPSTREAM service must be running.
   # https://proxy.projectname.vm
   proxy:
-    build: outrigger/https-proxy:1.0
+    image: outrigger/https-proxy:1.0
     container_name: projectname_http_proxy
     depends_on:
       - api


### PR DESCRIPTION
'build' can be specified either as a string containing a path to the build context.
Specify the 'image' instead when start the container from image.